### PR TITLE
Allow to use a different port other than 443 or 80

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -54,7 +54,9 @@ radosgw-S3 library provides access to {Ceph's radosgw storage}[http://docs.ceph.
     require "radosgw-s3"
     service = S3::Service.new(:access_key_id => "...",
                               :secret_access_key => "...",
-			      :host => "127.0.0.1")
+			                        :host => "127.0.0.1",
+                              :port => 8000 # Defaults to 443 or 80 if not set
+                             )
 
 === List buckets
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -54,7 +54,7 @@ radosgw-S3 library provides access to {Ceph's radosgw storage}[http://docs.ceph.
     require "radosgw-s3"
     service = S3::Service.new(:access_key_id => "...",
                               :secret_access_key => "...",
-			                        :host => "127.0.0.1",
+                              :host => "127.0.0.1",
                               :port => 8000 # Defaults to 443 or 80 if not set
                              )
 

--- a/lib/s3/connection.rb
+++ b/lib/s3/connection.rb
@@ -3,7 +3,7 @@ module S3
   class Connection
     include Parser
 
-    attr_accessor :access_key_id, :secret_access_key, :use_ssl, :timeout, :debug, :proxy, :host
+    attr_accessor :access_key_id, :secret_access_key, :use_ssl, :timeout, :debug, :proxy, :host, :custom_port
     alias_method :use_ssl?, :use_ssl
 
     # Creates new connection object.
@@ -30,6 +30,7 @@ module S3
       @timeout = options.fetch(:timeout, 60)
       @proxy = options.fetch(:proxy, nil)
       @chunk_size = options.fetch(:chunk_size, 1_048_576)
+      @custom_port = options.fetch(:port, false)
     end
 
     # Makes request with given HTTP method, sets missing parameters,
@@ -162,7 +163,7 @@ module S3
     private
 
     def port
-      use_ssl ? 443 : 80
+      custom_port ? custom_port : (use_ssl ? 443 : 80)
     end
 
     def proxy_settings

--- a/lib/s3/service.rb
+++ b/lib/s3/service.rb
@@ -3,7 +3,7 @@ module S3
     include Parser
     include Proxies
 
-    attr_reader :access_key_id, :secret_access_key, :use_ssl, :use_vhost, :proxy, :host
+    attr_reader :access_key_id, :secret_access_key, :use_ssl, :use_vhost, :proxy, :host, :custom_port
 
     # Compares service to other, by <tt>access_key_id</tt> and
     # <tt>secret_access_key</tt>
@@ -38,6 +38,7 @@ module S3
       @use_vhost = options.fetch(:use_vhost, true)
       @timeout = options.fetch(:timeout, 60)
       @debug = options.fetch(:debug, false)
+      @custom_port = options.fetch(:port, false)
 
       fail ArgumentError, 'Missing proxy settings. Must specify at least :host.' if options[:proxy] && !options[:proxy][:host]
       @proxy = options.fetch(:proxy, nil)
@@ -70,7 +71,7 @@ module S3
     # Returns 443 or 80, depends on <tt>:use_ssl</tt> value from
     # initializer
     def port
-      use_ssl ? 443 : 80
+      custom_port ? custom_port : (use_ssl ? 443 : 80)
     end
 
     def inspect #:nodoc:
@@ -97,6 +98,7 @@ module S3
                                    use_ssl: @use_ssl,
                                    timeout: @timeout,
                                    debug: @debug,
+                                   port: @custom_port,
                                    proxy: @proxy)
     end
   end


### PR DESCRIPTION
Adds a new parameter `port`, which when present, behaves as currently.